### PR TITLE
Build Break Fix: Transition unit tests to conftest aws client fixtures

### DIFF
--- a/source/tests/unit/application/archive_transfer/test_download.py
+++ b/source/tests/unit/application/archive_transfer/test_download.py
@@ -2,13 +2,11 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
-import boto3
 import pytest
 import typing
 from unittest.mock import patch
 from datetime import timedelta
 from refreezer.application.archive_transfer.download import GlacierDownload
-from moto import mock_glacier  # type: ignore
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_glacier.client import GlacierClient
@@ -17,43 +15,40 @@ else:
     GlacierClient = object
     InitiateJobOutputTypeDef = object
 
+TEST_DATA = b"test"
 
-@mock_glacier  # type: ignore[misc]
-def test_init() -> None:
-    job_id = setup_glacier()
+
+def test_init(setup_glacier_job: str) -> None:
     vault_name: str = "vault_name"
     start_byte: int = 0
     end_byte: int = 1024
     chunk_size: int = 256
 
     # Create a GlacierDownload object
-    download = GlacierDownload(job_id, vault_name, start_byte, end_byte, chunk_size)
+    download = GlacierDownload(
+        setup_glacier_job, vault_name, start_byte, end_byte, chunk_size
+    )
 
     # Test that the object was initialized correctly
-    assert download.params["jobId"] == job_id
+    assert download.params["jobId"] == setup_glacier_job
     assert download.params["vaultName"] == vault_name
     assert download.params["range"] == f"bytes={start_byte}-{end_byte}"
     assert download.chunk_size == chunk_size
 
 
-@mock_glacier  # type: ignore[misc]
-def test_iter_correctness() -> None:
-    test_response: bytes = b"test"
-    job_id = setup_glacier(test_response)
-    download = GlacierDownload(job_id, "vault_name", 0, 1024, 1)
+def test_iter_correctness(setup_glacier_job: str) -> None:
+    download = GlacierDownload(setup_glacier_job, "vault_name", 0, 1024, 1)
 
     # Test that iter() method returns the correct chunks
     chunks: list[bytes] = []
     for chunk in download:
         chunks.append(chunk)
-    assert len(chunks) == len(test_response)
-    assert b"".join(chunks) == test_response
+    assert len(chunks) == len(TEST_DATA)
+    assert b"".join(chunks) == TEST_DATA
 
 
-@mock_glacier  # type: ignore[misc]
-def test_iter_prevents_second_access() -> None:
-    job_id = setup_glacier()
-    download = GlacierDownload(job_id, "vault_name", 0, 1024, 1)
+def test_iter_prevents_second_access(setup_glacier_job: str) -> None:
+    download = GlacierDownload(setup_glacier_job, "vault_name", 0, 1024, 1)
 
     for _ in download:
         pass
@@ -62,13 +57,15 @@ def test_iter_prevents_second_access() -> None:
             pass
 
 
-def setup_glacier(test_body: bytes = b"test") -> str:
-    glacier: GlacierClient = boto3.client("glacier", region_name="us-east-1")
-    glacier.create_vault(vaultName="vault_name")
-    archive_response = glacier.upload_archive(vaultName="vault_name", body=test_body)
+@pytest.fixture
+def setup_glacier_job(glacier_client: GlacierClient) -> str:
+    glacier_client.create_vault(vaultName="vault_name")
+    archive_response = glacier_client.upload_archive(
+        vaultName="vault_name", body=TEST_DATA
+    )
     archive_id = archive_response["archiveId"]
     with patch("datetime.timedelta", return_value=timedelta(seconds=0)):
-        job_response: InitiateJobOutputTypeDef = glacier.initiate_job(
+        job_response: InitiateJobOutputTypeDef = glacier_client.initiate_job(
             vaultName="vault_name",
             jobParameters={
                 "Type": "archive-retrieval",

--- a/source/tests/unit/application/archive_transfer/test_upload.py
+++ b/source/tests/unit/application/archive_transfer/test_upload.py
@@ -3,10 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import boto3
 import typing
 from refreezer.application.archive_transfer.upload import S3Upload
-from moto import mock_s3  # type: ignore
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
@@ -14,10 +12,8 @@ else:
     S3Client = object
 
 
-@mock_s3  # type: ignore[misc]
-def test_initiate_multipart_upload() -> None:
-    s3: S3Client = boto3.client("s3")
-    s3.create_bucket(Bucket="test-bucket")
+def test_initiate_multipart_upload(s3_client: S3Client) -> None:
+    s3_client.create_bucket(Bucket="test-bucket")
 
     s3_upload = S3Upload(
         bucket_name="test-bucket", key="test-key", archive_id="test-archive-id"
@@ -25,10 +21,8 @@ def test_initiate_multipart_upload() -> None:
     assert s3_upload.upload_id is not None
 
 
-@mock_s3  # type: ignore[misc]
-def test_upload_part() -> None:
-    s3: S3Client = boto3.client("s3")
-    s3.create_bucket(Bucket="test-bucket")
+def test_upload_part(s3_client: S3Client) -> None:
+    s3_client.create_bucket(Bucket="test-bucket")
 
     s3_upload = S3Upload(
         bucket_name="test-bucket", key="test-key", archive_id="test-archive-id"
@@ -37,10 +31,8 @@ def test_upload_part() -> None:
     assert s3_upload.part_number == 2
 
 
-@mock_s3  # type: ignore[misc]
-def test_complete_upload() -> None:
-    s3: S3Client = boto3.client("s3")
-    s3.create_bucket(Bucket="test-bucket")
+def test_complete_upload(s3_client: S3Client) -> None:
+    s3_client.create_bucket(Bucket="test-bucket")
 
     s3_upload = S3Upload(
         bucket_name="test-bucket", key="test-key", archive_id="test-archive-id"
@@ -50,10 +42,8 @@ def test_complete_upload() -> None:
     assert s3_upload.completed is True
 
 
-@mock_s3  # type: ignore[misc]
-def test_upload_part_after_complete() -> None:
-    s3: S3Client = boto3.client("s3")
-    s3.create_bucket(Bucket="test-bucket")
+def test_upload_part_after_complete(s3_client: S3Client) -> None:
+    s3_client.create_bucket(Bucket="test-bucket")
 
     s3_upload = S3Upload(
         bucket_name="test-bucket", key="test-key", archive_id="test-archive-id"

--- a/source/tests/unit/conftest.py
+++ b/source/tests/unit/conftest.py
@@ -1,0 +1,45 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import os
+import typing
+
+import boto3
+import pytest
+
+from moto import mock_s3, mock_glacier  # type: ignore
+
+
+if typing.TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+    from mypy_boto3_glacier import GlacierClient
+else:
+    S3Client = object
+    GlacierClient = object
+
+
+@pytest.fixture(scope="module")
+def aws_credentials() -> None:
+    """Mocked AWS Credentials for moto"""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    os.environ["AWS_REGION"] = "us-east-1"
+
+
+@pytest.fixture(scope="module")
+def s3_client(aws_credentials: None) -> typing.Iterator[S3Client]:
+    with mock_s3():
+        connection: S3Client = boto3.client("s3", region_name="us-east-1")
+        yield connection
+
+
+@pytest.fixture(scope="module")
+def glacier_client(aws_credentials: None) -> typing.Iterator[GlacierClient]:
+    with mock_glacier():
+        connection: GlacierClient = boto3.client("glacier", region_name="us-east-1")
+        yield connection


### PR DESCRIPTION
*Issue*: [Asana](https://app.asana.com/0/1202938635037719/1204155451636591/f)

*Description of changes:*
- Includes a unit test conftest.py to hold AWS boto3 pytest fixtures
- Fixes pipeline synth break by having fixture set region env variable
- Updates existing test_download and test_upload to use new fixtures

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
