### PR TITLE
Includes Glacier/S3 checksum calculation and verification to the archive transfer lambda

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -1,0 +1,4 @@
+# Emails are expected in these files
+CODE_OF_CONDUCT.md:4
+CONTRIBUTING.md:50
+layers

--- a/source/refreezer/application/archive_transfer/facilitator.py
+++ b/source/refreezer/application/archive_transfer/facilitator.py
@@ -3,10 +3,21 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 from refreezer.application.archive_transfer.download import GlacierDownload
 from refreezer.application.archive_transfer.upload import S3Upload
+from refreezer.application.hashing.tree_hash import TreeHash
 from concurrent import futures
+
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.type_defs import (
+        CompletedPartTypeDef,
+    )
+else:
+    CompletedPartTypeDef = object
+
+MAX_UPLOAD_WORKERS = 2
 
 
 class ArchiveTransferFacilitator:
@@ -35,7 +46,7 @@ class ArchiveTransferFacilitator:
         self.upload_id = upload_id
         self.part_number = part_number
 
-    def transfer_archive(self) -> None:
+    def transfer_archive(self) -> list[CompletedPartTypeDef]:
         archive_download = GlacierDownload(
             self.job_id,
             self.vault_name,
@@ -50,11 +61,26 @@ class ArchiveTransferFacilitator:
             self.upload_id,
             self.part_number,
         )
-
-        with futures.ThreadPoolExecutor(max_workers=2) as upload_executor:
-            upload_futures = [
-                upload_executor.submit(archive_upload.upload_part, chunk)
-                for chunk in archive_download
-            ]
-            for future in upload_futures:
-                future.result()
+        with futures.ThreadPoolExecutor(
+            max_workers=MAX_UPLOAD_WORKERS
+        ) as upload_executor:
+            glacier_hash = TreeHash()
+            upload_futures = set()
+            completed_futures = set()
+            for chunk in archive_download:
+                upload_futures.add(
+                    upload_executor.submit(archive_upload.upload_part, chunk)
+                )
+                glacier_hash.update(chunk)
+                if len(upload_futures) > MAX_UPLOAD_WORKERS:
+                    completed, upload_futures = futures.wait(
+                        upload_futures, return_when=futures.FIRST_COMPLETED
+                    )
+                    completed_futures.update(completed)
+            completed, _ = futures.wait(
+                upload_futures, return_when=futures.ALL_COMPLETED
+            )
+            completed_futures.update(completed)
+        if glacier_hash.digest().hex() != archive_download.checksum():
+            raise Exception("Glacier checksum mismatch")
+        return [future.result() for future in completed_futures]

--- a/source/refreezer/application/archive_transfer/upload.py
+++ b/source/refreezer/application/archive_transfer/upload.py
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 import boto3
 import typing
+from base64 import b64encode, b64decode
+from refreezer.application.hashing.s3_hash import S3Hash
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
@@ -36,6 +38,11 @@ class S3Upload:
         self.archive_id = archive_id
         self.parts: list[CompletedPartTypeDef] = []
 
+        if (part_number is None) ^ (upload_id is None):
+            raise Exception(
+                "Both part_number and upload_id must be provided to continue an upload"
+            )
+
         self.part_number = part_number or 1
         self.upload_id = upload_id or self._initiate_multipart_upload()
 
@@ -43,11 +50,11 @@ class S3Upload:
 
     def _initiate_multipart_upload(self) -> str:
         response: CreateMultipartUploadOutputTypeDef = self.s3.create_multipart_upload(
-            Bucket=self.bucket_name, Key=self.key
+            Bucket=self.bucket_name, Key=self.key, ChecksumAlgorithm="SHA256"
         )
         return response["UploadId"]
 
-    def upload_part(self, chunk: bytes) -> None:
+    def upload_part(self, chunk: bytes) -> CompletedPartTypeDef:
         if self.completed:
             raise Exception("Upload already completed")
         part_number = self.part_number
@@ -58,16 +65,37 @@ class S3Upload:
             Key=self.key,
             PartNumber=part_number,
             UploadId=self.upload_id,
+            ChecksumAlgorithm="SHA256",
+            ChecksumSHA256=(checksum := b64encode(S3Hash.hash(chunk)).decode("ascii")),
         )
-        self.parts.insert(
-            part_number - 1, {"PartNumber": part_number, "ETag": response["ETag"]}
-        )
+        return self.include_part(part_number, response["ETag"], checksum)
+
+    def include_part(
+        self, part_number: int, etag: str, checksum: str
+    ) -> CompletedPartTypeDef:
+        if self.completed:
+            raise Exception("Upload already completed")
+        part: CompletedPartTypeDef = {
+            "PartNumber": part_number,
+            "ETag": etag,
+            "ChecksumSHA256": checksum,
+        }
+        self.parts.insert(part_number - 1, part)
+        return part
 
     def complete_upload(self) -> None:
+        s3_hash = S3Hash()
+        for part in self.parts:
+            s3_hash.include(
+                b64decode(part["ChecksumSHA256"].encode("ascii")),
+                part["PartNumber"] - 1,
+            )
+
         self.s3.complete_multipart_upload(
             Bucket=self.bucket_name,
             Key=self.key,
             UploadId=self.upload_id,
             MultipartUpload={"Parts": self.parts},
+            ChecksumSHA256=b64encode(s3_hash.digest()).decode("ascii"),
         )
         self.completed = True

--- a/source/refreezer/application/hashing/s3_hash.py
+++ b/source/refreezer/application/hashing/s3_hash.py
@@ -4,13 +4,17 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import hashlib
+import typing
 
 
 class S3Hash:
     def __init__(self) -> None:
         self.hashes: list[bytes] = []
 
-    def include(self, hash: bytes) -> None:
+    def include(self, hash: bytes, index: typing.Optional[int] = None) -> None:
+        if index is not None:
+            self.hashes.insert(index, hash)
+            return
         self.hashes.append(hash)
 
     def _concat(self) -> bytes:

--- a/source/refreezer/infrastructure/stack.py
+++ b/source/refreezer/infrastructure/stack.py
@@ -459,13 +459,23 @@ class RefreezerStack(Stack):
             ],
         )
 
+        boto3_lambda_layer = lambda_.LayerVersion(
+            self,
+            "boto3_lambda_layer",
+            code=lambda_.Code.from_asset("layers/boto3.zip"),
+            compatible_runtimes=[lambda_.Runtime.PYTHON_3_9],
+            license="Apache-2.0",
+            description="A Boto3 layer to use (v1.26.70) rather than the default provided by lambda",
+        )
+
         chunk_retrieval_lambda = lambda_.Function(
             self,
             "ChunkRetrieval",
             handler="refreezer.application.handlers.chunk_retrieval_lambda_handler",
             runtime=lambda_.Runtime.PYTHON_3_9,
             code=lambda_.Code.from_asset("source"),
-            memory_size=4096,
+            layers=[boto3_lambda_layer],
+            memory_size=2560,
             timeout=Duration.minutes(15),
             description="Lambda to retrieve chunks from Glacier, upload them to S3 and generate file checksums.",
         )

--- a/source/tests/unit/application/archive_transfer/test_upload.py
+++ b/source/tests/unit/application/archive_transfer/test_upload.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import typing
+import pytest
 from refreezer.application.archive_transfer.upload import S3Upload
 
 if typing.TYPE_CHECKING:
@@ -23,12 +24,81 @@ def test_initiate_multipart_upload(s3_client: S3Client) -> None:
 
 def test_upload_part(s3_client: S3Client) -> None:
     s3_client.create_bucket(Bucket="test-bucket")
-
     s3_upload = S3Upload(
         bucket_name="test-bucket", key="test-key", archive_id="test-archive-id"
     )
     s3_upload.upload_part(chunk=b"test-chunk")
     assert s3_upload.part_number == 2
+
+
+def test_include_part(s3_client: S3Client) -> None:
+    s3_client.create_bucket(Bucket="test-bucket")
+    s3_upload = S3Upload(
+        bucket_name="test-bucket", key="test-key", archive_id="test-archive-id"
+    )
+    s3_upload.include_part(part_number=1, etag="test-etag", checksum="test-checksum")
+    assert s3_upload.parts == [
+        {"PartNumber": 1, "ETag": "test-etag", "ChecksumSHA256": "test-checksum"}
+    ]
+
+
+def test_include_part_out_of_order(s3_client: S3Client) -> None:
+    s3_client.create_bucket(Bucket="test-bucket")
+    s3_upload = S3Upload(
+        bucket_name="test-bucket", key="test-key", archive_id="test-archive-id"
+    )
+    s3_upload.include_part(part_number=2, etag="test-etag", checksum="test-checksum")
+    s3_upload.include_part(part_number=1, etag="test-etag", checksum="test-checksum")
+    assert s3_upload.parts == [
+        {"PartNumber": 1, "ETag": "test-etag", "ChecksumSHA256": "test-checksum"},
+        {"PartNumber": 2, "ETag": "test-etag", "ChecksumSHA256": "test-checksum"},
+    ]
+
+
+def test_include_part_after_complete(s3_client: S3Client) -> None:
+    s3_client.create_bucket(Bucket="test-bucket")
+    s3_upload = S3Upload(
+        bucket_name="test-bucket", key="test-key", archive_id="test-archive-id"
+    )
+    s3_upload.upload_part(chunk=b"test-chunk")
+    s3_upload.complete_upload()
+    with pytest.raises(Exception):
+        s3_upload.include_part(
+            part_number=2, etag="test-etag", checksum="test-checksum"
+        )
+
+
+def test_resume_multipart_upload_completion(s3_client: S3Client) -> None:
+    s3_client.create_bucket(Bucket="test-bucket")
+    s3_upload = S3Upload(
+        bucket_name="test-bucket", key="test-key", archive_id="test-archive-id"
+    )
+    part = s3_upload.upload_part(chunk=b"test-chunk")
+    s3_upload = S3Upload(
+        bucket_name="test-bucket",
+        key="test-key",
+        archive_id="test-archive-id",
+        part_number=2,
+        upload_id=s3_upload.upload_id,
+    )
+    s3_upload.include_part(part["PartNumber"], part["ETag"], part["ChecksumSHA256"])
+    s3_upload.complete_upload()
+    assert s3_upload.completed
+
+
+def test_resume_multipart_upload_without_upload_id(s3_client: S3Client) -> None:
+    s3_client.create_bucket(Bucket="test-bucket")
+    s3_upload = S3Upload(
+        bucket_name="test-bucket", key="test-key", archive_id="test-archive-id"
+    )
+    part = s3_upload.upload_part(chunk=b"test-chunk")
+    with pytest.raises(Exception):
+        s3_upload = S3Upload(
+            bucket_name="test-bucket",
+            key="test-key",
+            archive_id="test-archive-id",
+            part_number=2,
+        )
 
 
 def test_complete_upload(s3_client: S3Client) -> None:
@@ -39,7 +109,7 @@ def test_complete_upload(s3_client: S3Client) -> None:
     )
     s3_upload.upload_part(chunk=b"test-chunk")
     s3_upload.complete_upload()
-    assert s3_upload.completed is True
+    assert s3_upload.completed
 
 
 def test_upload_part_after_complete(s3_client: S3Client) -> None:
@@ -50,8 +120,6 @@ def test_upload_part_after_complete(s3_client: S3Client) -> None:
     )
     s3_upload.upload_part(chunk=b"test-chunk")
     s3_upload.complete_upload()
-    assert s3_upload.completed is True
-    try:
+    assert s3_upload.completed
+    with pytest.raises(Exception):
         s3_upload.upload_part(chunk=b"test-chunk")
-    except Exception as e:
-        assert e.args[0] == "Upload already completed"

--- a/source/tests/unit/infrastructure/test_stack.py
+++ b/source/tests/unit/infrastructure/test_stack.py
@@ -244,7 +244,7 @@ def test_chunk_retrieval_lambda_created(
             "Properties": {
                 "Handler": "refreezer.application.handlers.chunk_retrieval_lambda_handler",
                 "Runtime": "python3.9",
-                "MemorySize": 4096,
+                "MemorySize": 2560,
                 "Timeout": 900,
             },
         },


### PR DESCRIPTION
*Issue #, if available:* [S3Hash](https://app.asana.com/0/1202938635037719/1203960890664567/f), [GlacierHash](https://app.asana.com/0/1202938635037719/1203960890664565/f)

*Description of changes:*
- Modifies the archive transfer facilitator to create and validate the Glacier Tree hash for the archive data being transferred
- Modifies the S3Upload class to calculate and pass checksums for data being uploaded, along with calculating the overall checksum for the archive upon completing the multipart upload
- Adds and includes a boto3 layer (v1.26.70) to the Archive Transfer lambda to support Checksums validation on Multipart uploads
- Modifies the memory allocation for the lambda by having the Glacier download wait for the S3 upload if it gets too far ahead, preventing us from loading more than 3 chunks in memory at a time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
