### PR TITLE
Fix lambda event/response typing being included at runtime

### DIFF
--- a/source/refreezer/application/glacier_s3_transfer/facilitator.py
+++ b/source/refreezer/application/glacier_s3_transfer/facilitator.py
@@ -8,7 +8,6 @@ from refreezer.application.glacier_s3_transfer.download import GlacierDownload
 from refreezer.application.glacier_s3_transfer.upload import S3Upload
 from refreezer.application.hashing.tree_hash import TreeHash
 from refreezer.application.util.exceptions import GlacierChecksumMismatch
-from refreezer.application.model import responses
 from base64 import b64encode
 
 
@@ -16,8 +15,12 @@ if TYPE_CHECKING:
     from mypy_boto3_s3.type_defs import (
         CompletedPartTypeDef,
     )
+    from refreezer.application.model.responses import (
+        GlacierRetrieval as GlacierRetrievalResponse,
+    )
 else:
     CompletedPartTypeDef = object
+    GlacierRetrievalResponse = object
 
 
 class GlacierToS3Facilitator:
@@ -48,14 +51,14 @@ class GlacierToS3Facilitator:
 
         self.ignore_glacier_checksum = ignore_glacier_checksum
 
-    def transfer(self) -> responses.GlacierRetrieval:
+    def transfer(self) -> GlacierRetrievalResponse:
         """
         Transfers a chunk of data from an AWS Glacier vault to an S3 bucket.
 
         Returns a dictionary containing information about the uploaded part.
 
         :return: A dictionary containing information about the uploaded part.
-        :rtype: responses.GlacierRetrieval
+        :rtype: GlacierRetrievalResponse
 
         :raises Exception: If the checksum of the downloaded chunk of data from Glacier does not match the expected checksum.
 

--- a/source/refreezer/application/glacier_s3_transfer/upload.py
+++ b/source/refreezer/application/glacier_s3_transfer/upload.py
@@ -7,7 +7,6 @@ import boto3
 import typing
 from base64 import b64encode, b64decode
 from refreezer.application.hashing.s3_hash import S3Hash
-from refreezer.application.model import responses
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
@@ -15,10 +14,14 @@ if typing.TYPE_CHECKING:
         UploadPartOutputTypeDef,
         CompleteMultipartUploadOutputTypeDef,
     )
+    from refreezer.application.model.responses import (
+        GlacierRetrieval as GlacierRetrievalResponse,
+    )
 else:
     S3Client = object
     UploadPartOutputTypeDef = object
     CompleteMultipartUploadOutputTypeDef = object
+    GlacierRetrievalResponse = object
 
 
 class S3Upload:
@@ -32,10 +35,10 @@ class S3Upload:
 
         self.bucket_name = bucket_name
         self.key = key
-        self.parts: list[responses.GlacierRetrieval] = []
+        self.parts: list[GlacierRetrievalResponse] = []
         self.upload_id = upload_id
 
-    def upload_part(self, chunk: bytes, part_number: int) -> responses.GlacierRetrieval:
+    def upload_part(self, chunk: bytes, part_number: int) -> GlacierRetrievalResponse:
         checksum = b64encode(S3Hash.hash(chunk)).decode("ascii")
         response: UploadPartOutputTypeDef = self.s3.upload_part(
             Body=chunk,
@@ -70,7 +73,7 @@ class S3Upload:
     @staticmethod
     def _build_part(
         part_number: int, etag: str, checksum: str
-    ) -> responses.GlacierRetrieval:
+    ) -> GlacierRetrievalResponse:
         return {
             "PartNumber": part_number,
             "ETag": etag,

--- a/source/refreezer/application/handlers.py
+++ b/source/refreezer/application/handlers.py
@@ -9,7 +9,7 @@ from typing import List, Dict, TYPE_CHECKING, Optional, Any
 
 from refreezer.application.facilitator.processor import sns_handler, dynamoDb_handler
 from refreezer.application.chunking.inventory import generate_chunk_array
-from refreezer.application.model import events, responses
+from refreezer.application.model import events
 from refreezer.application.glacier_s3_transfer.facilitator import (
     GlacierToS3Facilitator,
 )
@@ -18,9 +18,13 @@ from refreezer.application.glacier_s3_transfer.facilitator import (
 if TYPE_CHECKING:
     from mypy_boto3_stepfunctions.client import SFNClient
     from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSEvent
+    from refreezer.application.model.responses import (
+        GlacierRetrieval as GlacierRetrievalResponse,
+    )
 else:
     SFNClient = object
     SQSEvent = object
+    GlacierRetrievalResponse = object
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -37,7 +41,7 @@ def async_facilitator_handler(event: SQSEvent, _: Optional[Dict[str, Any]]) -> N
 
 def chunk_retrieval_lambda_handler(
     event: events.ArchiveRetrieval, _context: Any
-) -> responses.GlacierRetrieval:
+) -> GlacierRetrievalResponse:
     logger.info("Chunk retrieval lambda has been invoked.")
 
     facilitator = GlacierToS3Facilitator(
@@ -80,7 +84,7 @@ def inventory_chunk_lambda_handler(
 
 def inventory_chunk_download_lambda_handler(
     event: events.GlacierRetrieval, _context: Any
-) -> responses.GlacierRetrieval:
+) -> GlacierRetrievalResponse:
     logger.info("Chunk retrieval lambda has been invoked.")
 
     facilitator = GlacierToS3Facilitator(


### PR DESCRIPTION
*Issue #, if available:* We're currently seeing an issue where the event and response types used by our lambdas are being included at runtime and the handlers try to import dependencies which are only installed in development

*Description of changes:*
- Fixes the above. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
