### PR TITLE
Swap start and endbyte to byte_range string on download lambdas

### DIFF
--- a/source/refreezer/application/glacier_s3_transfer/download.py
+++ b/source/refreezer/application/glacier_s3_transfer/download.py
@@ -17,16 +17,10 @@ else:
 
 
 class GlacierDownload:
-    def __init__(
-        self,
-        job_id: str,
-        vault_name: str,
-        start_byte: int,
-        end_byte: int,
-    ) -> None:
+    def __init__(self, job_id: str, vault_name: str, byte_range: str) -> None:
         self.params = {
             "jobId": job_id,
-            "range": f"bytes={start_byte}-{end_byte}",
+            "range": f"bytes={byte_range}",
             "vaultName": vault_name,
         }
         self.glacier: GlacierClient = boto3.client("glacier")

--- a/source/refreezer/application/glacier_s3_transfer/facilitator.py
+++ b/source/refreezer/application/glacier_s3_transfer/facilitator.py
@@ -28,8 +28,7 @@ class GlacierToS3Facilitator:
         self,
         job_id: str,
         vault_name: str,
-        start_byte: int,
-        end_byte: int,
+        byte_range: str,
         glacier_object_id: str,
         s3_destination_bucket: str,
         s3_destination_key: str,
@@ -39,9 +38,7 @@ class GlacierToS3Facilitator:
     ) -> None:
         self.job_id = job_id
         self.vault_name = vault_name
-        self.start_byte = start_byte
-        self.end_byte = end_byte
-
+        self.byte_range = byte_range
         self.glacier_object_id = glacier_object_id
 
         self.s3_destination_bucket = s3_destination_bucket
@@ -67,8 +64,7 @@ class GlacierToS3Facilitator:
         download = GlacierDownload(
             self.job_id,
             self.vault_name,
-            self.start_byte,
-            self.end_byte,
+            self.byte_range,
         )
         upload = S3Upload(
             self.s3_destination_bucket,

--- a/source/refreezer/application/handlers.py
+++ b/source/refreezer/application/handlers.py
@@ -47,8 +47,7 @@ def chunk_retrieval_lambda_handler(
     facilitator = GlacierToS3Facilitator(
         event["JobId"],
         event["VaultName"],
-        event["StartByte"],
-        event["EndByte"],
+        event["ByteRange"],
         event["ArchiveId"],
         event["S3DestinationBucket"],
         event["S3DestinationKey"],
@@ -90,8 +89,7 @@ def inventory_chunk_download_lambda_handler(
     facilitator = GlacierToS3Facilitator(
         event["JobId"],
         event["VaultName"],
-        event["StartByte"],
-        event["EndByte"],
+        event["ByteRange"],
         event["VaultName"],
         event["S3DestinationBucket"],
         event["S3DestinationKey"],

--- a/source/refreezer/application/model/events.py
+++ b/source/refreezer/application/model/events.py
@@ -9,8 +9,7 @@ from typing import TypedDict
 class GlacierRetrieval(TypedDict):
     JobId: str
     VaultName: str
-    StartByte: int
-    EndByte: int
+    ByteRange: str
     S3DestinationBucket: str
     S3DestinationKey: str
     UploadId: str

--- a/source/tests/unit/application/glacier_s3_transfer/test_download.py
+++ b/source/tests/unit/application/glacier_s3_transfer/test_download.py
@@ -21,20 +21,19 @@ TEST_DATA = b"test"
 
 def test_init(setup_glacier_job: str) -> None:
     vault_name: str = "vault_name"
-    start_byte: int = 0
-    end_byte: int = 1024
+    byte_range: str = "0-1024"
 
     # Create a GlacierDownload object
-    download = GlacierDownload(setup_glacier_job, vault_name, start_byte, end_byte)
+    download = GlacierDownload(setup_glacier_job, vault_name, byte_range)
 
     # Test that the object was initialized correctly
     assert download.params["jobId"] == setup_glacier_job
     assert download.params["vaultName"] == vault_name
-    assert download.params["range"] == f"bytes={start_byte}-{end_byte}"
+    assert download.params["range"] == f"bytes={byte_range}"
 
 
 def test_read_correctness(setup_glacier_job: str) -> None:
-    download = GlacierDownload(setup_glacier_job, "vault_name", 0, 1024)
+    download = GlacierDownload(setup_glacier_job, "vault_name", "0-1024")
 
     # Test that iter() method returns the correct chunks
     chunk: bytes = download.read()
@@ -42,7 +41,7 @@ def test_read_correctness(setup_glacier_job: str) -> None:
 
 
 def test_read_prevents_second_access(setup_glacier_job: str) -> None:
-    download = GlacierDownload(setup_glacier_job, "vault_name", 0, 1024)
+    download = GlacierDownload(setup_glacier_job, "vault_name", "0-1024")
     download.read()
     with pytest.raises(AccessViolation):
         download.read()

--- a/source/tests/unit/application/glacier_s3_transfer/test_facilitator.py
+++ b/source/tests/unit/application/glacier_s3_transfer/test_facilitator.py
@@ -17,8 +17,7 @@ class TestGlacierToS3Facilitator(unittest.TestCase):
     def setUp(self) -> None:
         self.job_id = "job1"
         self.vault_name = "vault1"
-        self.start_byte = 0
-        self.end_byte = 100
+        self.byte_range = "0-100"
         self.glacier_object_id = "archive1"
         self.s3_destination_bucket = "bucket1"
         self.s3_destination_key = "key1"
@@ -37,8 +36,7 @@ class TestGlacierToS3Facilitator(unittest.TestCase):
         facilitator = self.create_facilitator()
         self.assertEqual(facilitator.job_id, self.job_id)
         self.assertEqual(facilitator.vault_name, self.vault_name)
-        self.assertEqual(facilitator.start_byte, self.start_byte)
-        self.assertEqual(facilitator.end_byte, self.end_byte)
+        self.assertEqual(facilitator.byte_range, self.byte_range)
         self.assertEqual(facilitator.glacier_object_id, self.glacier_object_id)
         self.assertEqual(facilitator.s3_destination_bucket, self.s3_destination_bucket)
         self.assertEqual(facilitator.s3_destination_key, self.s3_destination_key)
@@ -118,8 +116,7 @@ class TestGlacierToS3Facilitator(unittest.TestCase):
         return GlacierToS3Facilitator(
             self.job_id,
             self.vault_name,
-            self.start_byte,
-            self.end_byte,
+            self.byte_range,
             self.glacier_object_id,
             self.s3_destination_bucket,
             self.s3_destination_key,


### PR DESCRIPTION
*Description of changes:*
- Replaces `StartByte` and `EndByte` event parameters in download lambdas with a single `ByteRange` string to be passed along to Glacier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
