### PR TITLE
Propagate data to the Download lambda function

### DIFF
--- a/source/refreezer/mocking/mock_glacier_stack.py
+++ b/source/refreezer/mocking/mock_glacier_stack.py
@@ -49,6 +49,7 @@ class MockGlacierStack(Stack):
             scope,
             "MockGlacierInitiateJobTask",
             lambda_function=mock_glacier_initiate_job_lambda,
+            result_path="$.initiate_job_result",
             payload_response_only=True,
         )
 

--- a/source/tests/integration/infrastructure/test_inventory_retrieval_step_function.py
+++ b/source/tests/integration/infrastructure/test_inventory_retrieval_step_function.py
@@ -33,6 +33,8 @@ def default_input() -> str:
             vault_name="test-vault-01",
             description="This is a test",
             sns_topic=topic_arn,
+            workflow_run="workflow_run_123",
+            upload_id="test_upload_123",
         )
     )
 


### PR DESCRIPTION
*Description of changes:*
Configure Get inventory step functions states to propagate relevant data to the Download lambda function
- JobId
- VaultName
- S3DestinationBucket
- S3DestinationKey
- ByteRange
- PartNumber
- UploadId

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
